### PR TITLE
Add missing HACS & manifest items, bump openai library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # hass-openai-custom-conversation
+
 Conversation support for home assistant using local llm for example vicuna or something else
 
 How to setup your own local LLM for Home assistant:
+
 - Install local-ai
 - Setup model
 - Install hass-openai-custom-conversation

--- a/custom_components/vicuna_conversation/config_flow.py
+++ b/custom_components/vicuna_conversation/config_flow.py
@@ -28,6 +28,8 @@ from .const import (
     CONF_TEMPERATURE,
     CONF_TOP_P,
     CONF_BASE_URL,
+    DEFAULT_API_KEY,
+    DEFAULT_BASE_URL,
     DEFAULT_CHAT_MODEL,
     DEFAULT_MAX_TOKENS,
     DEFAULT_PROMPT,
@@ -40,8 +42,8 @@ _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_API_KEY): str,
-        vol.Required(CONF_BASE_URL): str,
+        vol.Required(CONF_API_KEY, default=DEFAULT_API_KEY): str,
+        vol.Required(CONF_BASE_URL, default=DEFAULT_BASE_URL): str,
     }
 )
 
@@ -52,6 +54,8 @@ DEFAULT_OPTIONS = types.MappingProxyType(
         CONF_MAX_TOKENS: DEFAULT_MAX_TOKENS,
         CONF_TOP_P: DEFAULT_TOP_P,
         CONF_TEMPERATURE: DEFAULT_TEMPERATURE,
+        CONF_API_KEY: DEFAULT_API_KEY,
+        CONF_BASE_URL: DEFAULT_BASE_URL,
     }
 )
 

--- a/custom_components/vicuna_conversation/const.py
+++ b/custom_components/vicuna_conversation/const.py
@@ -33,3 +33,4 @@ CONF_TEMPERATURE = "temperature"
 DEFAULT_TEMPERATURE = 0.5
 CONF_BASE_URL = "base_url"
 DEFAULT_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_API_KEY = "sk-0000000000000000000"

--- a/custom_components/vicuna_conversation/info.md
+++ b/custom_components/vicuna_conversation/info.md
@@ -1,0 +1,5 @@
+# HomeAssistant OpenAI Custom Conversation
+
+OpenAI compatible API integration for HomeAssistant.
+
+For use with custom / local LLMs that provide an OpenAI compatible API.

--- a/custom_components/vicuna_conversation/manifest.json
+++ b/custom_components/vicuna_conversation/manifest.json
@@ -1,12 +1,13 @@
 {
-  "domain": "custom_openai_conversation",
-  "name": "Custom OpenAI Conversation",
   "codeowners": ["@drndos"],
   "config_flow": true,
   "dependencies": ["conversation"],
   "documentation": "https://github.com/drndos/hass-openai-custom-conversation",
+  "domain": "custom_openai_conversation",
   "integration_type": "service",
   "iot_class": "local_polling",
-  "requirements": ["openai==0.27.2"],
-  "version": "0.7"
+  "issue_tracker": "https://github.com/drndos/hass-openai-custom-conversation/issues",
+  "name": "Custom OpenAI Conversation",
+  "requirements": ["openai==0.27.8"],
+  "version": "0.8"
 }

--- a/custom_components/vicuna_conversation/strings.json
+++ b/custom_components/vicuna_conversation/strings.json
@@ -1,28 +1,30 @@
 {
   "config": {
-    "step": {
-      "user": {
-        "data": {
-          "api_key": "[%key:common::config_flow::data::api_key%]"
-        }
-      }
-    },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "api_key": "[%key:common::config_flow::data::api_key%]",
+          "base_url": "[%key:common::config_flow::data::url%]"
+        }
+      }
     }
   },
   "options": {
     "step": {
       "init": {
         "data": {
-          "prompt": "Prompt Template",
-          "model": "Completion Model",
+          "api_key": "API Key",
+          "base_url": "API Base URL",
           "max_tokens": "Maximum tokens to return in response",
+          "model": "Completion Model",
+          "prompt": "Prompt Template",
           "temperature": "Temperature",
-          "top_p": "Top P",
-          "base_url": "Base URL"
+          "top_p": "Top P"
         }
       }
     }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Custom OpenAI Conversation",
   "render_readme": true,
-  "homeassistant": "2023.8.0"
+  "homeassistant": "2023.8.0",
+  "topics": ["conversation"]
 }


### PR DESCRIPTION
Howdy!

I had started work on my own plugin doing pretty much the same thing you had but haven't had as much time to work on it as I'd like.

So I thought I'll submit a PR to your repo to add in a couple of small things.

- Bump the OpenAI library to current stable version.
- Add the missing default parameters to the strings and config flow.
- Adding missing manifest and HACS items (you'll need those to submit it to the HACS store at some point).

Before:

![image](https://github.com/drndos/hass-openai-custom-conversation/assets/862951/8c9a685b-4803-4199-9efd-74d5cabaa741)

After:

![SCR-20230811-jwaw](https://github.com/drndos/hass-openai-custom-conversation/assets/862951/debbc579-33b7-48fd-a05a-61b1301885a5)

---


What I haven't looked into yet but want to:

- Why the text descriptions on the config input boxes aren't displaying (at least they have pretty obvious defaults now).
- Adding optional functionality so users can select and download a model from a [gallery](https://localai.io/models/).
- Add a home assistant service, so it can be used in automation beyond the conversation scope.
- Adding an option to select the module as an input parameter to your query, e.g. "Hey Home Assistant ask [ScienceBot] what the newest discovered element is)"